### PR TITLE
feat: configurable checkpoint saving interval

### DIFF
--- a/modules/train.py
+++ b/modules/train.py
@@ -1,3 +1,4 @@
+import os
 import torch
 from torch import optim
 from tqdm import tqdm
@@ -85,6 +86,10 @@ class RETrainer(BaseTrainer):
 
                 if epoch >= self.args.eval_begin_epoch:
                     self.evaluate(epoch)   # generator to dev.
+                if self.args.save_path is not None and epoch % getattr(self.args, 'save_epochs', 1) == 0:
+                    ckpt_path = os.path.join(self.args.save_path, f"epoch_{epoch}.pth")
+                    torch.save(self.model.state_dict(), ckpt_path)
+                    self.logger.info("Save checkpoint at {}".format(ckpt_path))
             
             pbar.close()
             self.pbar = None
@@ -335,6 +340,10 @@ class NERTrainer(BaseTrainer):
 
                 if epoch >= self.args.eval_begin_epoch:
                     self.evaluate(epoch)   # generator to dev.
+                if self.args.save_path is not None and epoch % getattr(self.args, 'save_epochs', 1) == 0:
+                    ckpt_path = os.path.join(self.args.save_path, f"epoch_{epoch}.pth")
+                    torch.save(self.model.state_dict(), ckpt_path)
+                    self.logger.info("Save checkpoint at {}".format(ckpt_path))
 
             torch.cuda.empty_cache()
             

--- a/run.py
+++ b/run.py
@@ -134,6 +134,7 @@ def main():
     parser.add_argument('--prompt_dim', default=800, type=int, help="mid dimension of prompt project layer")
     parser.add_argument('--load_path', default=None, type=str, help="Load model from load_path")
     parser.add_argument('--save_path', default=None, type=str, help="save model at save_path")
+    parser.add_argument('--save_epochs', default=1, type=int, help="save checkpoint every n epochs")
     parser.add_argument('--write_path', default=None, type=str,
                         help="do_test=True, predictions will be write in write_path")
     parser.add_argument('--notes', default="", type=str, help="input some remarks for making save path dir.")

--- a/run_re_task.sh
+++ b/run_re_task.sh
@@ -19,4 +19,6 @@ CUDA_VISIBLE_DEVICES=0 python -u run.py \
         --prompt_len=4 \
         --sample_ratio=1.0 \
         --save_path='ckpt/re/' \
+        --save_epochs=1 \
         --resnet_path=${RESNET_NAME}
+

--- a/run_twitter15.sh
+++ b/run_twitter15.sh
@@ -28,4 +28,6 @@ CUDA_VISIBLE_DEVICES=1 python -u run.py \
         --use_prompt \
         --prompt_len=4 \
         --sample_ratio=1.0 \
-        --save_path=your_ckpt_path
+        --save_path=your_ckpt_path \
+        --save_epochs=1
+

--- a/run_twitter17.sh
+++ b/run_twitter17.sh
@@ -26,4 +26,6 @@ CUDA_VISIBLE_DEVICES=3 python -u run.py \
         --use_prompt \
         --prompt_len=4 \
         --sample_ratio=1.0 \
-        --save_path=your_ckpt_path
+        --save_path=your_ckpt_path \
+        --save_epochs=1
+


### PR DESCRIPTION
## Summary
- allow setting `--save_epochs` to control checkpoint frequency
- save model checkpoints at the end of every `save_epochs`
- update example run scripts with the new option

## Testing
- `python -m py_compile run.py modules/train.py`


------
https://chatgpt.com/codex/tasks/task_e_68bacdac69ec8325a3ad8a7f49ac895a