### PR TITLE
feat: add test script for RE task

### DIFF
--- a/test_re_task.sh
+++ b/test_re_task.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+DATASET_NAME="MRE"
+BERT_NAME="models/roberta-base"
+RESNET_NAME="models/resnet50/resnet50-11ad3fa6.pth"
+LOAD_PATH="ckpt/re/best_model.pth"
+SEED=1234
+
+CUDA_VISIBLE_DEVICES=0 python -u run.py \
+        --dataset_name=${DATASET_NAME} \
+        --bert_name=${BERT_NAME} \
+        --seed=${SEED} \
+        --only_test \
+        --max_seq=80 \
+        --use_prompt \
+        --prompt_len=4 \
+        --sample_ratio=1.0 \
+        --load_path=${LOAD_PATH} \
+        --resnet_path=${RESNET_NAME}


### PR DESCRIPTION
## Summary
- add `test_re_task.sh` to run RE task in test mode with pre-trained checkpoints

## Testing
- `bash -n test_re_task.sh`
- `bash test_re_task.sh` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68bae1a4a30483259c72f81d4571094c