### PR TITLE
Make CUDA device configurable

### DIFF
--- a/run_re_task.sh
+++ b/run_re_task.sh
@@ -4,7 +4,9 @@ DATASET_NAME="MRE"
 BERT_NAME="models/roberta-base"
 RESNET_NAME="models/resnet50/resnet50-11ad3fa6.pth"
 
-CUDA_VISIBLE_DEVICES=0 python -u run.py \
+GPU_ID=${1:-0}
+
+CUDA_VISIBLE_DEVICES=${GPU_ID} python -u run.py \
         --dataset_name=${DATASET_NAME} \
         --bert_name=${BERT_NAME} \
         --num_epochs=3 \

--- a/run_twitter15.sh
+++ b/run_twitter15.sh
@@ -13,7 +13,9 @@ BERT_NAME="bert-base-uncased"
 
 lr=3e-5
 
-CUDA_VISIBLE_DEVICES=1 python -u run.py \
+GPU_ID=${1:-0}
+
+CUDA_VISIBLE_DEVICES=${GPU_ID} python -u run.py \
         --dataset_name=${DATASET_NAME} \
         --bert_name=${BERT_NAME} \
         --num_epochs=30 \

--- a/run_twitter17.sh
+++ b/run_twitter17.sh
@@ -11,7 +11,9 @@
 DATASET_NAME="twitter17"
 BERT_NAME="bert-base-uncased"
 
-CUDA_VISIBLE_DEVICES=3 python -u run.py \
+GPU_ID=${1:-0}
+
+CUDA_VISIBLE_DEVICES=${GPU_ID} python -u run.py \
         --dataset_name=${DATASET_NAME} \
         --bert_name=${BERT_NAME} \
         --num_epochs=30 \

--- a/test_re_task.sh
+++ b/test_re_task.sh
@@ -6,7 +6,9 @@ RESNET_NAME="models/resnet50/resnet50-11ad3fa6.pth"
 LOAD_PATH="ckpt/re/best_model.pth"
 SEED=1234
 
-CUDA_VISIBLE_DEVICES=0 python -u run.py \
+GPU_ID=${1:-0}
+
+CUDA_VISIBLE_DEVICES=${GPU_ID} python -u run.py \
         --dataset_name=${DATASET_NAME} \
         --bert_name=${BERT_NAME} \
         --seed=${SEED} \


### PR DESCRIPTION
## Summary
- allow configuring CUDA device for relation extraction training
- enable GPU selection for relation extraction testing
- support GPU selection in Twitter15 and Twitter17 training scripts

## Testing
- `bash -n run_re_task.sh test_re_task.sh run_twitter15.sh run_twitter17.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bae2ec7edc8325ab4a307faae9ddd5