### PR TITLE
feat: log per-class test statistics

### DIFF
--- a/modules/metrics.py
+++ b/modules/metrics.py
@@ -1,3 +1,6 @@
+from sklearn.metrics import confusion_matrix
+
+
 def eval_result(true_labels, pred_result, rel2id, logger, use_name=False):
     correct = 0
     total = len(true_labels)
@@ -44,3 +47,19 @@ def eval_result(true_labels, pred_result, rel2id, logger, use_name=False):
     result = {'acc': acc, 'micro_p': micro_p, 'micro_r': micro_r, 'micro_f1': micro_f1}
     logger.info('Evaluation result: {}.'.format(result))
     return result
+
+
+def log_detailed_results(true_labels, pred_labels, rel2id, logger):
+    """输出每个类别以及总体的测试情况。"""
+    labels = list(rel2id.values())[1:]
+    names = list(rel2id.keys())[1:]
+    cm = confusion_matrix(true_labels, pred_labels, labels=labels)
+    total_samples = int(cm.sum())
+    total_success = int(cm.trace())
+    total_fail = int(total_samples - total_success)
+    for idx, name in enumerate(names):
+        total = int(cm[idx].sum())
+        success = int(cm[idx][idx])
+        fail = int(total - success)
+        logger.info(f"类别{name}: 总数{total}, 成功{success}, 失败{fail}")
+    logger.info(f"总计: 总数{total_samples}, 成功{total_success}, 失败{total_fail}")

--- a/modules/train.py
+++ b/modules/train.py
@@ -7,7 +7,7 @@ from sklearn.metrics import classification_report as sk_classification_report
 from seqeval.metrics import classification_report
 from transformers.optimization import get_linear_schedule_with_warmup
 
-from .metrics import eval_result
+from .metrics import eval_result, log_detailed_results
 
 class BaseTrainer(object):
     def train(self):
@@ -119,8 +119,11 @@ class RETrainer(BaseTrainer):
                     pbar.update()
                 # evaluate done
                 pbar.close()
-                sk_result = sk_classification_report(y_true=true_labels, y_pred=pred_labels, labels=list(self.re_dict.values())[1:], target_names=list(self.re_dict.keys())[1:], digits=4)
+                sk_result = sk_classification_report(y_true=true_labels, y_pred=pred_labels,
+                                                    labels=list(self.re_dict.values())[1:],
+                                                    target_names=list(self.re_dict.keys())[1:], digits=4)
                 self.logger.info("%s\n", sk_result)
+                log_detailed_results(true_labels, pred_labels, self.re_dict, self.logger)
                 result = eval_result(true_labels, pred_labels, self.re_dict, self.logger)
                 acc, micro_f1 = round(result['acc']*100, 4), round(result['micro_f1']*100, 4)
                 if self.writer:
@@ -168,8 +171,11 @@ class RETrainer(BaseTrainer):
                     pbar.update()
                 # evaluate done
                 pbar.close()
-                sk_result = sk_classification_report(y_true=true_labels, y_pred=pred_labels, labels=list(self.re_dict.values())[1:], target_names=list(self.re_dict.keys())[1:], digits=4)
+                sk_result = sk_classification_report(y_true=true_labels, y_pred=pred_labels,
+                                                    labels=list(self.re_dict.values())[1:],
+                                                    target_names=list(self.re_dict.keys())[1:], digits=4)
                 self.logger.info("%s\n", sk_result)
+                log_detailed_results(true_labels, pred_labels, self.re_dict, self.logger)
                 result = eval_result(true_labels, pred_labels, self.re_dict, self.logger)
                 acc, micro_f1 = round(result['acc']*100, 4), round(result['micro_f1']*100, 4)
                 if self.writer:


### PR DESCRIPTION
## Summary
- add detailed test summary output for each relation and overall counts

## Testing
- `python -m py_compile modules/metrics.py modules/train.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc37db30ec832582985b7cba0ea5e1