### PR TITLE
为RE测试添加逐样本日志输出并支持config.yaml配置

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,6 @@
+logging:
+  level: INFO
+  sample_prefix: "测试样本"
+  input_label: "输入"
+  gold_label: "正确答案"
+  pred_label: "模型预测"

--- a/modules/logging_utils.py
+++ b/modules/logging_utils.py
@@ -1,0 +1,26 @@
+import os
+import yaml
+
+
+def load_logging_config(logger, config_path=None):
+    default_config = {
+        "level": "INFO",
+        "sample_prefix": "测试样本",
+        "input_label": "输入",
+        "gold_label": "正确答案",
+        "pred_label": "模型预测",
+    }
+    config_path = config_path or os.path.join(os.getcwd(), "config.yaml")
+    if not os.path.exists(config_path):
+        logger.debug("未找到config.yaml，使用默认日志配置。")
+        return default_config
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except Exception as exc:
+        logger.warning("读取config.yaml失败，使用默认配置: %s", exc)
+        return default_config
+    logging_cfg = data.get("logging", {})
+    merged = default_config.copy()
+    merged.update({k: v for k, v in logging_cfg.items() if v is not None})
+    return merged

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ TorchCRF==1.1.0
 wandb==0.12.1
 scikit-learn==1.0
 seqeval==1.2.2
+PyYAML==6.0.1

--- a/run.py
+++ b/run.py
@@ -13,6 +13,7 @@ from torch.utils.data import DataLoader
 from models.bert_model import HMNeTREModel, HMNeTNERModel
 from processor.dataset import MMREProcessor, MMPNERProcessor, MMREDataset, MMPNERDataset
 from modules.train import RETrainer, NERTrainer
+from modules.logging_utils import load_logging_config
 
 import warnings
 
@@ -23,7 +24,9 @@ logging.basicConfig(format='%(asctime)s - %(levelname)s - %(name)s -   %(message
                     datefmt='%m/%d/%Y %H:%M:%S',
                     level=logging.INFO)
 logger = logging.getLogger(__name__)
-logging.getLogger().setLevel(logging.INFO)
+logging_config = load_logging_config(logger)
+logging_level = getattr(logging, str(logging_config.get("level", "INFO")).upper(), logging.INFO)
+logging.getLogger().setLevel(logging_level)
 
 MODEL_CLASSES = {
     'MRE': HMNeTREModel,


### PR DESCRIPTION
### Motivation

- 需要在运行 `test_re_task.sh` / `run.py --only_test` 时按示例格式将每条测试样本的输入、正确答案和模型预测以 info 级别打印出来并换行显示以便前端展示和人工检查。 
- 希望将日志相关的静态配置（如前缀、标签、日志级别）抽到配置文件中以便复用和后续扩展。 

### Description

- 新增 `config.yaml` 用于存放日志配置项（`level`、`sample_prefix`、`input_label`、`gold_label`、`pred_label`）。
- 新增 `modules/logging_utils.py` 提供 `load_logging_config`，读取 `config.yaml` 并返回合并后的默认/用户配置。 
- 修改 `run.py` 在程序入口加载日志配置并根据 `config.yaml` 设置全局日志级别。 
- 修改 `modules/train.py` 的 `RETrainer.test`，在测试循环中按样本打印信息（格式为“测试样本 n/m\n输入=...\n正确答案=...\n模型预测=...”），并增加 debug 级别的批次/样本详细日志，同时使用从配置加载的标签文本；为日志加载使用了 `load_logging_config`。 
- 更新 `requirements.txt` 增加 `PyYAML` 以支持读取 YAML 配置文件。 

### Testing

- 尝试运行简化的 Python 脚本以调用 `RETrainer._log_test_samples` 进行功能验证的自动化测试（运行脚本时发生导入错误，因为运行环境缺少 `torch`），因此该自动化测试未成功通过。 
- 在无法运行真实模型的环境下对修改点进行了静态检查（文件存在性和按行查看），这些检查通过且文件已生成。 
- 建议在带有完整依赖（包含 `torch`）的 CI 或本地环境中运行 `run.py --only_test` 或 `test_re_task.sh` 来验证逐样本日志输出和前端展示是否符合预期。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967aa8b978883258b46e8e0651501f6)