### PR TITLE
通过配置文件设置 PIL 日志级别以抑制噪声

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,9 @@ logging:
   level: "DEBUG"
   format: "%(asctime)s - %(levelname)s - %(name)s -   %(message)s"
   datefmt: "%m/%d/%Y %H:%M:%S"
+  logger_levels:
+    PIL: "WARNING"
+    PIL.PngImagePlugin: "WARNING"
   test_sample_labels:
     sample: "测试样本"
     input: "输入"

--- a/run.py
+++ b/run.py
@@ -130,6 +130,13 @@ def main():
     log_datefmt = log_config.get("datefmt", "%m/%d/%Y %H:%M:%S")
     logging.basicConfig(format=log_format, datefmt=log_datefmt, level=log_level)
     logging.getLogger().setLevel(log_level)
+    logger_levels = log_config.get("logger_levels", {})
+    for logger_name, level_name in logger_levels.items():
+        level_value = getattr(logging, str(level_name).upper(), None)
+        if level_value is None:
+            continue
+        logging.getLogger(logger_name).setLevel(level_value)
+        logger.debug("Set logger %s level to %s", logger_name, level_name)
     logger.debug("Loaded config from %s: %s", os.path.join(os.path.dirname(__file__), "config.yaml"), config)
 
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
### Motivation
- 抑制来自 PIL（如 `PIL.PngImagePlugin`）的大量 DEBUG 输出，同时保留全局和其他 logger 的调试信息以便排查问题。

### Description
- 在 `config.yaml` 中新增 `logging.logger_levels` 字段，可以为指定 logger 设置级别（示例：将 `PIL` 与 `PIL.PngImagePlugin` 设为 `WARNING`）。
- 在 `run.py` 启动流程中读取 `logging.logger_levels` 并对指定 logger 应用级别设置，同时保留一条 debug 日志记录设置结果。 

### Testing
- 运行了一个小型自动化脚本来调用 `modules.train.format_re_test_sample_log` 的示例（通过 `python - <<'PY' ... PY`），该脚本在当前环境中失败并报错：`ModuleNotFoundError: No module named 'torch'`，因此未能在该环境下完成示例执行验证。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967af793aa483258950702ec326501d)